### PR TITLE
Fallow Mateusz code review suggestions.

### DIFF
--- a/shm/Island.cpp
+++ b/shm/Island.cpp
@@ -1,23 +1,17 @@
 #include "Island.hpp"
 #include <string>
 
-Island::Island(coordinateType positionX, coordinateType positionY)
+Island::Island(Island::coordinateType positionX, Island::coordinateType positionY)
     : position_{positionX, positionY} {}
 
-Island::Coordinates Island::getPosition() const {
-    return position_;
-}
-
-Island::Coordinates::Coordinates(coordinateType positionX, coordinateType positionY)
+constexpr Island::Coordinates::Coordinates(Island::coordinateType positionX, Island::coordinateType positionY)
     : positionX_{positionX}, positionY_{positionY} {}
 
-std::string Island::Coordinates::toString() {
-    return "x: " + std::to_string(positionX_) + ", y: " + std::to_string(positionY_);
+bool Island::Coordinates::operator==(const Coordinates& other) const {
+    return positionX_ == other.positionX_ and positionY_ == other.positionY_;
 }
 
-bool Island::Coordinates::operator==(const Coordinates& other) const {
-    if (positionX_ == other.positionX_ and positionY_ == other.positionY_) {
-        return true;
-    }
-    return false;
+std::ostream& operator<<(std::ostream& out, const Island::Coordinates& coords){
+    out << "x: " << coords.positionX_ << ", y: " << coords.positionY_ << '\n';
+    return out;
 }

--- a/shm/Island.hpp
+++ b/shm/Island.hpp
@@ -1,27 +1,28 @@
 #pragma once
 #include <cstdint>
 #include <string>
-
-using coordinateType = std::size_t;
-
+#include <iostream>
 class Island {
 public:
+    using coordinateType = std::size_t;
+
     Island(coordinateType positionX, coordinateType positionY);
 
     class Coordinates {
     public:
-        Coordinates(coordinateType positionsX, coordinateType positionY);
-        std::string toString();
-
+        constexpr Coordinates(Island::coordinateType positionX, Island::coordinateType positionY);
+        friend std::ostream& operator<<(std::ostream& out, const Coordinates& coords);
         bool operator==(const Coordinates& other) const;
-
     private:
-        const coordinateType positionX_;
-        const coordinateType positionY_;
+        const Island::coordinateType positionX_;
+        const Island::coordinateType positionY_;
     };
 
-    Coordinates getPosition() const;
-
+    constexpr Coordinates getPosition() const{
+        return position_;
+    }
 private:
     const Coordinates position_;
 };
+
+std::ostream& operator<<(std::ostream& out, const Island::Coordinates& coords);

--- a/shm/Map.cpp
+++ b/shm/Map.cpp
@@ -1,7 +1,7 @@
 #include "Map.hpp"
 #include <algorithm>
 
-coordinateType generatePosition() {
+Island::coordinateType generatePosition() {
     std::random_device rd;
     std::mt19937 gen(rd());
     std::uniform_int_distribution<> distrib(0, 10);

--- a/shm/main.cpp
+++ b/shm/main.cpp
@@ -68,7 +68,7 @@ void testIslandMap() {
         std::cout << "\n\n--- MAP/ISLAND TEST ---\n";
         for(const auto& island : mapVec) {
             std::cout << num++ << ". ";
-            std::cout << island.getPosition().toString();
+            std::cout << island.getPosition();
             std::cout << '\n';
         }
     }


### PR DESCRIPTION
Insert coordinate type into Island class. 
Island::Coordinate can be constexpr now. 
Made Island::getPosition constexpr as well. 
Change Coordinates::toString to friend operator<< for Coordinates.
Remove if-else in Island::Coordinates::operator==.